### PR TITLE
TOP_pex_extracted.spiceは差分を取るように変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 **/gf180_drc.lyrdb
 **/lvs_temp.cdl
 **/TOP**
+!**/TOP_pex_extracted.spice
 **.DS_STORE


### PR DESCRIPTION
`TOP_pex_extracted.spice`は差分をとったほうが良さそうなので，ignoreから除外してみました．